### PR TITLE
feat: Set default time to current time and round down

### DIFF
--- a/index.html
+++ b/index.html
@@ -1824,7 +1824,7 @@
                 hours += 24;
             }
 
-            let currentTime = Math.round((hours + minutes / 60) * 2) / 2;
+            let currentTime = Math.floor((hours + minutes / 60) * 2) / 2;
 
             // Clamp to slider range
             if (currentTime < 12) currentTime = 12;


### PR DESCRIPTION
- Sets the default time and day to the user's current time and day.
- Rounds the initial time down to the nearest half-hour as requested.